### PR TITLE
Update redirect for unauthenticated state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,12 +8,12 @@ export default function Home() {
 	const router = useRouter();
 	const { status } = useSession(); // 'authenticated', 'unauthenticated', or 'loading'
 
-	useEffect(() => {
-		if (status === 'unauthenticated') {
-			router.push('/dashboard');
-		} else if (status === 'authenticated') {
-			router.push('/dashboard');
-		}
+        useEffect(() => {
+                if (status === 'unauthenticated') {
+                        router.push('/login');
+                } else if (status === 'authenticated') {
+                        router.push('/dashboard');
+                }
 		// 'loading' state does nothing - we wait for the session to resolve
 	}, [status, router]);
 


### PR DESCRIPTION
## Summary
- correct redirection for unauthenticated users

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684106c6565c832aa9ee9473b99c84c9